### PR TITLE
Add loots/log/debug file rotator

### DIFF
--- a/Unbroken_v1.0/COC Bot.au3
+++ b/Unbroken_v1.0/COC Bot.au3
@@ -55,6 +55,7 @@ WEnd
 
 Func runBot() ;Bot that runs everything in order
 	While 1
+		loot_log_cleanup(100)
 		SaveConfig()
 		readConfig()
 		applyConfig()
@@ -312,3 +313,25 @@ Func Pause()
 		If _Sleep(1000) Then Return
 	WEnd
 EndFunc   ;==>Pause
+
+Func loot_log_cleanup($no_rotator)
+	local $dir_list[3] = ["Loots", "logs", "Debug"]
+	For $l = 0 To UBound($dir_list) - 1
+		local $dir = @ScriptDir & "\" & $dir_list[$l]
+		if FileExists($dir) == 0 then
+			SetLog("dir not found - " & $dir, $COLOR_RED)
+			continueloop
+		endif
+		local $fArray = _FileListToArrayRec($dir, "*", $FLTAR_FILESFOLDERS, $FLTAR_RECUR, $FLTAR_SORT, $FLTAR_FULLPATH )
+		if UBound($fArray) == 0 Then continueloop
+		local $data_size = $fArray[0]
+		if $data_size > $no_rotator Then
+			For $i = 1 To Number($data_size - $no_rotator)
+				local $file_path = $fArray[$i]
+				If Not FileDelete($file_path) Then
+					SetLog("Fail to del " & $file_path, $COLOR_RED)
+				EndIf
+			Next
+		endif
+	Next
+EndFunc


### PR DESCRIPTION
This ensure the total number of files in loots/log/debug directory is under 100

Just a suggested feature, maybe the number of file to be kept should be a gui based.